### PR TITLE
feat(calendly-api): pull events from Calendly API

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -113,5 +113,6 @@
 		"track",
 		"width",
 		"zIndex"
-	]
+	],
+	"editor.tabSize": 2
 }

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -18,6 +18,7 @@ declare global {
 			internalNote: string;
 			uid: string;
 			duration: string;
+			tags: string[];
 		}
 	}
 }

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -7,3 +7,19 @@ declare namespace App {
 	// interface Error {}
 	// interface Platform {}
 }
+
+declare global {
+	namespace Calendly {
+		interface EventTypeData {
+			active: boolean;
+			description: string;
+			name: string;
+			schedulingUrl: string;
+			internalNote: string;
+			uid: string;
+			duration: string;
+		}
+	}
+}
+
+export { };

--- a/src/lib/components/CalendlyPopupButton.svelte
+++ b/src/lib/components/CalendlyPopupButton.svelte
@@ -25,3 +25,9 @@
 <button class="btn bg-primary-500 text-white" on:click={initializeCalendly}>
   <slot />
 </button>
+
+<style>
+  .calendly-overlay .calendly-popup {
+    max-height: 690px;
+  }
+</style>

--- a/src/lib/components/EventsPanel.svelte
+++ b/src/lib/components/EventsPanel.svelte
@@ -23,11 +23,11 @@
 	<div class="grid grid-cols-1 gap-2">
 		{#if events.length > 0}
 			{#each events as event}
-				<div class="flex items-center p-2 border rounded-lg">
+				<div class="flex items-center p-2 border rounded-lg min-h-[6rem]">
 					<CalendlyPopupButton bookingLink={event.bookingLink}>Book</CalendlyPopupButton>
 					<div class="ml-4 flex-grow">
 						<h3 class="font-semibold">{event.title}</h3>
-						<p class="text-sm text-gray-600 truncate">{event.description}</p>
+						<p class="text-sm text-gray-600 break-words line-clamp-2">{event.description}</p>
 					</div>
 					<!-- <div class="ml-4 min-w-fit">
 						<span class="block text-sm bg-gray-100 py-2 px-4 rounded" aria-label="Event Date">

--- a/src/lib/components/EventsPanel.svelte
+++ b/src/lib/components/EventsPanel.svelte
@@ -1,14 +1,15 @@
 <script lang="ts">
 	import CalendlyPopupButton from './CalendlyPopupButton.svelte';
-import Card from './Card.svelte';
+	import Card from './Card.svelte';
 
 	export let events: Array<{
 		id: string;
 		title: string;
 		description: string;
-		date: string;
-		imageSrc: string;
+		// date: string;
+		// imageSrc: string;
 		bookingLink: string;
+		duration: string;
 	}>;
 	export let title = 'Featured Events';
 	export let description = '';
@@ -23,17 +24,14 @@ import Card from './Card.svelte';
 		{#each events as event}
 			<div class="flex items-center p-2 border rounded-lg">
 				<CalendlyPopupButton bookingLink={event.bookingLink}>Book</CalendlyPopupButton>
-				<!-- <div class="w-16 h-16 bg-gray-100 rounded-lg overflow-hidden">
-					<img src={event.imageSrc} alt={event.title} class="object-cover w-full h-full" />
-				</div> -->
 				<div class="ml-4 flex-grow">
 					<h3 class="font-semibold">{event.title}</h3>
 					<p class="text-sm text-gray-600 truncate">{event.description}</p>
 				</div>
-				<div class="ml-4">
-					<span class="block text-sm bg-gray-100 py-2 px-4 rounded" aria-label="Event Date">
+				<div class="ml-4 min-w-fit">
+					<span class="block text-sm bg-gray-100 py-2 px-4 rounded" aria-label="Event Duration">
 						<img class="mx-auto" src="$lib/assets/design/icons/calendar.svg" alt="" aria-hidden />
-						{event.date}
+						{event.duration}
 					</span>
 				</div>
 			</div>

--- a/src/lib/components/EventsPanel.svelte
+++ b/src/lib/components/EventsPanel.svelte
@@ -28,12 +28,12 @@
 					<h3 class="font-semibold">{event.title}</h3>
 					<p class="text-sm text-gray-600 truncate">{event.description}</p>
 				</div>
-				<div class="ml-4 min-w-fit">
-					<span class="block text-sm bg-gray-100 py-2 px-4 rounded" aria-label="Event Duration">
+				<!-- <div class="ml-4 min-w-fit">
+					<span class="block text-sm bg-gray-100 py-2 px-4 rounded" aria-label="Event Date">
 						<img class="mx-auto" src="$lib/assets/design/icons/calendar.svg" alt="" aria-hidden />
-						{event.duration}
+						{event.date}
 					</span>
-				</div>
+				</div> -->
 			</div>
 		{/each}
 	</div>

--- a/src/lib/components/EventsPanel.svelte
+++ b/src/lib/components/EventsPanel.svelte
@@ -21,21 +21,25 @@
 		<p class="text-center text-gray-600 mb-4">{description}</p>
 	{/if}
 	<div class="grid grid-cols-1 gap-2">
-		{#each events as event}
-			<div class="flex items-center p-2 border rounded-lg">
-				<CalendlyPopupButton bookingLink={event.bookingLink}>Book</CalendlyPopupButton>
-				<div class="ml-4 flex-grow">
-					<h3 class="font-semibold">{event.title}</h3>
-					<p class="text-sm text-gray-600 truncate">{event.description}</p>
+		{#if events.length > 0}
+			{#each events as event}
+				<div class="flex items-center p-2 border rounded-lg">
+					<CalendlyPopupButton bookingLink={event.bookingLink}>Book</CalendlyPopupButton>
+					<div class="ml-4 flex-grow">
+						<h3 class="font-semibold">{event.title}</h3>
+						<p class="text-sm text-gray-600 truncate">{event.description}</p>
+					</div>
+					<!-- <div class="ml-4 min-w-fit">
+						<span class="block text-sm bg-gray-100 py-2 px-4 rounded" aria-label="Event Date">
+							<img class="mx-auto" src="$lib/assets/design/icons/calendar.svg" alt="" aria-hidden />
+							{event.date}
+						</span>
+					</div> -->
 				</div>
-				<!-- <div class="ml-4 min-w-fit">
-					<span class="block text-sm bg-gray-100 py-2 px-4 rounded" aria-label="Event Date">
-						<img class="mx-auto" src="$lib/assets/design/icons/calendar.svg" alt="" aria-hidden />
-						{event.date}
-					</span>
-				</div> -->
-			</div>
-		{/each}
+			{/each}
+		{:else}
+			<p class="text-center text-gray-600">No events to show.</p>
+		{/if}
 	</div>
 </Card>
 

--- a/src/lib/server/calendarUtils.ts
+++ b/src/lib/server/calendarUtils.ts
@@ -1,64 +1,74 @@
-import { CALENDLY_API_TOKEN, CALENDLY_API_URL, CALENDLY_USER_URI } from "$env/static/private";
+import { CALENDLY_API_TOKEN, CALENDLY_API_URL, CALENDLY_USER_URI } from '$env/static/private';
 
 const AUTH_HEADER = `Bearer ${CALENDLY_API_TOKEN}`;
 
-export const getEventDetails = async (
-  eventUuid: string,
-) => {
-  const eventTypeResponse = await fetch(`${CALENDLY_API_URL}/event_types/${eventUuid}`, {
-    method: 'GET',
-    headers: {
-      Authorization: AUTH_HEADER,
-      'Content-Type': 'application/json',
-    }
-  });
-  const eventTypeData: Calendly.EventTypeData = (await eventTypeResponse.json()).resource.map(mapCalendlyEventType);
-  return eventTypeData;
+export const getEventDetails = async (eventUuid: string) => {
+	const eventTypeResponse = await fetch(`${CALENDLY_API_URL}/event_types/${eventUuid}`, {
+		method: 'GET',
+		headers: {
+			Authorization: AUTH_HEADER,
+			'Content-Type': 'application/json'
+		}
+	});
+	const eventTypeData: Calendly.EventTypeData = (await eventTypeResponse.json()).resource.map(mapCalendlyEventType);
+	return eventTypeData;
 };
 
 export const getAllEventTypes = async () => {
-  const eventTypesResponse = await fetch(`${CALENDLY_API_URL}/event_types?user=${CALENDLY_USER_URI}`, {
-    method: 'GET',
-    headers: {
-      Authorization: AUTH_HEADER,
-      'Content-Type': 'application/json',
-    }
-  });
-  const allEventTypesData: Array<Calendly.EventTypeData> = (await eventTypesResponse.json()).collection.map(mapCalendlyEventType);
-  return allEventTypesData;
+	const eventTypesResponse = await fetch(`${CALENDLY_API_URL}/event_types?user=${CALENDLY_USER_URI}`, {
+		method: 'GET',
+		headers: {
+			Authorization: AUTH_HEADER,
+			'Content-Type': 'application/json'
+		}
+	});
+	const allEventTypesData: Array<Calendly.EventTypeData> = (await eventTypesResponse.json()).collection.map(
+		mapCalendlyEventType
+	);
+	return allEventTypesData;
 };
 
 // TODO: This is for the a list view of upcoming scheduled events on the Upcoming Events Page TBA
 export const getScheduledEvents = async () => {
-  const scheduledEventsResponse = await fetch(`${CALENDLY_API_URL}/scheduled_events?user=${CALENDLY_USER_URI}&sort=start_time:asc`, {
-    method: 'GET',
-    headers: {
-      Authorization: AUTH_HEADER,
-      'Content-Type': 'application/json',
-    }
-  });
-  const scheduledEventsResponseJson = await scheduledEventsResponse.json();
-  console.log(scheduledEventsResponseJson);
+	const scheduledEventsResponse = await fetch(
+		`${CALENDLY_API_URL}/scheduled_events?user=${CALENDLY_USER_URI}&sort=start_time:asc`,
+		{
+			method: 'GET',
+			headers: {
+				Authorization: AUTH_HEADER,
+				'Content-Type': 'application/json'
+			}
+		}
+	);
+	const scheduledEventsResponseJson = await scheduledEventsResponse.json();
+	console.log(scheduledEventsResponseJson);
+};
+
+const extractTags = (text: string): string[] => {
+	const hashtagRegex = /#(\w+)/g;
+	const matches = text.match(hashtagRegex);
+	return matches ? matches.map((match) => match.substring(1).toLowerCase()) : [];
 }
 
-const mapCalendlyEventType = ( eventTypeData ): Calendly.EventTypeData => {
-  return {
-    active: eventTypeData.active,
-    name: eventTypeData.name,
-    description: eventTypeData.description_plain,
-    schedulingUrl: eventTypeData.scheduling_url,
-    internalNote: eventTypeData.internal_note,
-    uid: eventTypeData.uri.split('/').pop(),
-    duration: eventTypeData.duration + ' min',
-  }
-}
+const mapCalendlyEventType = (eventTypeData): Calendly.EventTypeData => {
+	return {
+		active: eventTypeData.active,
+		name: eventTypeData.name,
+		description: eventTypeData.description_plain,
+		schedulingUrl: eventTypeData.scheduling_url,
+		internalNote: eventTypeData.internal_note,
+		tags: extractTags(eventTypeData.internal_note),
+		uid: eventTypeData.uri.split('/').pop(),
+		duration: eventTypeData.duration + ' min'
+	};
+};
 
-export const transformForEventPanel = ( events: Calendly.EventTypeData[] ) => {
-  return events.map((event: Calendly.EventTypeData) => ({
-    id: event.uid,
-    title: event.name,
-    description: event.description.substring(0, 20) + '...',
-    bookingLink: event.schedulingUrl, 
-    duration: event.duration,
-  }));
-}
+export const transformForEventPanel = (events: Calendly.EventTypeData[]) => {
+	return events.map((event: Calendly.EventTypeData) => ({
+		id: event.uid,
+		title: event.name,
+		description: event.description.substring(0, 36) + '...',
+		bookingLink: event.schedulingUrl,
+		duration: event.duration
+	}));
+};

--- a/src/lib/server/calendarUtils.ts
+++ b/src/lib/server/calendarUtils.ts
@@ -62,7 +62,6 @@ export const getScheduledEvents = async () => {
 		}
 	}
 	const scheduledEventsResponseJson = await scheduledEventsResponse.json();
-	console.log(scheduledEventsResponseJson);
 };
 
 const extractTags = (text: string): string[] => {
@@ -88,7 +87,7 @@ export const transformForEventPanel = (events: Calendly.EventTypeData[]) => {
 	return events.map((event: Calendly.EventTypeData) => ({
 		id: event.uid,
 		title: event.name,
-		description: event.description.substring(0, 36) + '...',
+		description: event.description,
 		bookingLink: event.schedulingUrl,
 		duration: event.duration
 	}));

--- a/src/lib/server/calendarUtils.ts
+++ b/src/lib/server/calendarUtils.ts
@@ -10,18 +10,32 @@ export const getEventDetails = async (eventUuid: string) => {
 			'Content-Type': 'application/json'
 		}
 	});
+	if (!eventTypeResponse.ok) {
+		if (eventTypeResponse.status === 404) {
+			throw new Error('Event not found');
+		} else {
+			throw new Error(`Failed to fetch event details. Status: ${eventTypeResponse.status}`);
+		}
+	}
 	const eventTypeData: Calendly.EventTypeData = (await eventTypeResponse.json()).resource.map(mapCalendlyEventType);
 	return eventTypeData;
 };
 
 export const getAllEventTypes = async () => {
-	const eventTypesResponse = await fetch(`${CALENDLY_API_URL}/event_types?user=${CALENDLY_USER_URI}`, {
+	const eventTypesResponse = await fetch(`${CALENDLY_API_URL}/event_types?user=${CALENDLY_USER_URI}&active=true`, {
 		method: 'GET',
 		headers: {
 			Authorization: AUTH_HEADER,
 			'Content-Type': 'application/json'
 		}
 	});
+	if (!eventTypesResponse.ok) {
+		if (eventTypesResponse.status === 404) {
+			throw new Error('No events found');
+		} else {
+			throw new Error(`Failed to fetch event details. Status: ${eventTypesResponse.status}`);
+		}
+	}
 	const allEventTypesData: Array<Calendly.EventTypeData> = (await eventTypesResponse.json()).collection.map(
 		mapCalendlyEventType
 	);
@@ -40,6 +54,13 @@ export const getScheduledEvents = async () => {
 			}
 		}
 	);
+	if (!scheduledEventsResponse.ok) {
+		if (scheduledEventsResponse.status === 404) {
+			throw new Error('Event not found');
+		} else {
+			throw new Error(`Failed to fetch event details. Status: ${scheduledEventsResponse.status}`);
+		}
+	}
 	const scheduledEventsResponseJson = await scheduledEventsResponse.json();
 	console.log(scheduledEventsResponseJson);
 };
@@ -48,7 +69,7 @@ const extractTags = (text: string): string[] => {
 	const hashtagRegex = /#(\w+)/g;
 	const matches = text.match(hashtagRegex);
 	return matches ? matches.map((match) => match.substring(1).toLowerCase()) : [];
-}
+};
 
 const mapCalendlyEventType = (eventTypeData): Calendly.EventTypeData => {
 	return {

--- a/src/lib/server/calendarUtils.ts
+++ b/src/lib/server/calendarUtils.ts
@@ -1,0 +1,64 @@
+import { CALENDLY_API_TOKEN, CALENDLY_API_URL, CALENDLY_USER_URI } from "$env/static/private";
+
+const AUTH_HEADER = `Bearer ${CALENDLY_API_TOKEN}`;
+
+export const getEventDetails = async (
+  eventUuid: string,
+) => {
+  const eventTypeResponse = await fetch(`${CALENDLY_API_URL}/event_types/${eventUuid}`, {
+    method: 'GET',
+    headers: {
+      Authorization: AUTH_HEADER,
+      'Content-Type': 'application/json',
+    }
+  });
+  const eventTypeData: Calendly.EventTypeData = (await eventTypeResponse.json()).resource.map(mapCalendlyEventType);
+  return eventTypeData;
+};
+
+export const getAllEventTypes = async () => {
+  const eventTypesResponse = await fetch(`${CALENDLY_API_URL}/event_types?user=${CALENDLY_USER_URI}`, {
+    method: 'GET',
+    headers: {
+      Authorization: AUTH_HEADER,
+      'Content-Type': 'application/json',
+    }
+  });
+  const allEventTypesData: Array<Calendly.EventTypeData> = (await eventTypesResponse.json()).collection.map(mapCalendlyEventType);
+  return allEventTypesData;
+};
+
+// TODO: This is for the a list view of upcoming scheduled events on the Upcoming Events Page TBA
+export const getScheduledEvents = async () => {
+  const scheduledEventsResponse = await fetch(`${CALENDLY_API_URL}/scheduled_events?user=${CALENDLY_USER_URI}&sort=start_time:asc`, {
+    method: 'GET',
+    headers: {
+      Authorization: AUTH_HEADER,
+      'Content-Type': 'application/json',
+    }
+  });
+  const scheduledEventsResponseJson = await scheduledEventsResponse.json();
+  console.log(scheduledEventsResponseJson);
+}
+
+const mapCalendlyEventType = ( eventTypeData ): Calendly.EventTypeData => {
+  return {
+    active: eventTypeData.active,
+    name: eventTypeData.name,
+    description: eventTypeData.description_plain,
+    schedulingUrl: eventTypeData.scheduling_url,
+    internalNote: eventTypeData.internal_note,
+    uid: eventTypeData.uri.split('/').pop(),
+    duration: eventTypeData.duration + ' min',
+  }
+}
+
+export const transformForEventPanel = ( events: Calendly.EventTypeData[] ) => {
+  return events.map((event: Calendly.EventTypeData) => ({
+    id: event.uid,
+    title: event.name,
+    description: event.description.substring(0, 20) + '...',
+    bookingLink: event.schedulingUrl, 
+    duration: event.duration,
+  }));
+}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -51,7 +51,7 @@
 							on:click={toggleMenu}
 							on:keypress={toggleMenu}
 						>
-							{#each [{ name: 'About', href: '/about' }, { name: 'Professionals', href: '/professionals' }, { name: 'Families', href: '/families' }, { name: 'Upcoming Events', href: '/events' }, { name: 'Volunteer', href: '/volunteer' }, { name: 'Contact Us', href: '/contact' }] as { name, href }}
+							{#each [{ name: 'About', href: '/about' }, { name: 'Professionals', href: '/professionals' }, { name: 'Families', href: '/families' }, { name: 'Events', href: '/events' }, { name: 'Volunteer', href: '/volunteer' }, { name: 'Contact Us', href: '/contact' }] as { name, href }}
 								<li>
 									<a {href}>
 										<span class:active={activePage === href} class="flex-auto">{name}</span>

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -1,0 +1,10 @@
+import { getAllEventTypes, transformForEventPanel } from "$lib/server/calendarUtils";
+import type { PageServerLoad } from "./$types";
+
+export const load = (async () => {
+  const allEventTypes: Array<Calendly.EventTypeData> = await getAllEventTypes();
+  const featuredEventData = transformForEventPanel(allEventTypes.filter(eventType => eventType.internalNote.toLowerCase().includes('featured')));
+  return {
+    featuredEventData,
+  }
+}) satisfies PageServerLoad;

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -1,10 +1,12 @@
-import { getAllEventTypes, transformForEventPanel } from "$lib/server/calendarUtils";
-import type { PageServerLoad } from "./$types";
+import { getAllEventTypes, transformForEventPanel } from '$lib/server/calendarUtils';
+import type { PageServerLoad } from './$types';
 
 export const load = (async () => {
-  const allEventTypes: Array<Calendly.EventTypeData> = await getAllEventTypes();
-  const featuredEventData = transformForEventPanel(allEventTypes.filter(eventType => eventType.internalNote.toLowerCase().includes('featured')));
-  return {
-    featuredEventData,
-  }
+	const allEventTypes: Array<Calendly.EventTypeData> = await getAllEventTypes();
+	const featuredEventData = transformForEventPanel(
+		allEventTypes.filter((eventType) => eventType.tags.includes('featured'))
+	);
+	return {
+		featuredEventData
+	};
 }) satisfies PageServerLoad;

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -2,11 +2,24 @@ import { getAllEventTypes, transformForEventPanel } from '$lib/server/calendarUt
 import type { PageServerLoad } from './$types';
 
 export const load = (async () => {
-	const allEventTypes: Array<Calendly.EventTypeData> = await getAllEventTypes();
-	const featuredEventData = transformForEventPanel(
-		allEventTypes.filter((eventType) => eventType.tags.includes('featured'))
-	);
-	return {
-		featuredEventData
-	};
+  try {
+    const allEventTypes: Array<Calendly.EventTypeData> = await getAllEventTypes();
+    const featuredEventData = transformForEventPanel(
+      allEventTypes.filter((eventType) => eventType.tags.includes('featured'))
+    );
+    // If allEventTypes is not empty but featuredEventData is empty, then there are no featured events - return top 3 events
+    if (allEventTypes.length > 0 && featuredEventData.length === 0) {
+      return {
+        featuredEventData: transformForEventPanel(allEventTypes.slice(0, 3))
+      };
+    }
+    return {
+      featuredEventData
+    };
+  } catch (error) {
+    console.error(error);
+    return {
+      featuredEventData: []
+    };
+  }
 }) satisfies PageServerLoad;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -40,7 +40,7 @@
 	max-md:bg-[url('$lib/assets/design/home-background-mobile.png')]"
 	id="hero"
 >
-	<div class="flex flex-row flex-wrap justify-around items-center relative">
+	<div class="flex flex-row flex-wrap justify-around items-center relative min-h-[20rem]">
 		<div class="h-fit mb-10">
 			<p class="text-white text-4xl max-w-md text-center">
 				We bring world-class maternal support to professionals and families

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,10 +1,13 @@
-<script>
+<script lang="ts">
 	import Bubble from '$lib/components/Bubble.svelte';
 	import EventsPanel from '$lib/components/EventsPanel.svelte';
-	import bkLogo from '$lib/assets/bk_logo.jpeg';
 	import { onMount } from 'svelte';
 	import { fade } from 'svelte/transition';
 	import ServiceCard from '$lib/components/ServiceCard.svelte';
+	import type { PageData } from './$types';
+
+	export let data: PageData;
+	const { featuredEventData } = data;
 	let mounted = false;
 	onMount(() => {
 		mounted = true;
@@ -49,32 +52,7 @@
 		</div>
 		<div class="flex flex-col items-center">
 			<EventsPanel
-			events={[
-				{
-					id: '123',
-					date: '07/12/23',
-					description: 'FREE Lecture',
-					title: 'Who is a Doula?',
-					imageSrc: bkLogo,
-					bookingLink: 'https://calendly.com/birthkuwait/free-lecture-who-is-a-doula-7-dec'
-				},
-				{
-					id: '123',
-					date: '02/12/23',
-					description: 'Professional Training',
-					title: 'One Hour Training',
-					imageSrc: bkLogo,
-					bookingLink: 'https://calendly.com/birthkuwait/professional-training'
-				},
-				{
-					id: '123',
-					date: 'Thursdays',
-					description: 'Basics Workshop',
-					title: 'Newborn Care',
-					imageSrc: bkLogo,
-					bookingLink: 'https://calendly.com/birthkuwait/newborn-care-basics-workshop'
-				}
-			]}
+			events={featuredEventData}
 		/>
 		<a class="btn bg-secondary-200 mt-4" href='/events'>See all events</a>
 		</div>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -50,7 +50,7 @@
 				<a class="btn bg-slate-200" href="/find-a-professional">Learn More</a>
 			</span>
 		</div>
-		<div class="flex flex-col items-center">
+		<div class="flex flex-col items-center max-w-[24rem]">
 			<EventsPanel
 			events={featuredEventData}
 		/>

--- a/src/routes/events/+page.svelte
+++ b/src/routes/events/+page.svelte
@@ -11,7 +11,7 @@
 	const onScriptLoad = () => {
 		Calendly.initInlineWidget({
 			url: 'https://calendly.com/birthkuwait',
-			parentElement: calendlyRef
+			parentElement: calendlyRef,
 		});
 	};
 
@@ -22,5 +22,9 @@
 	<script src="https://assets.calendly.com/assets/external/widget.js" async></script>
 </svelte:head>
 
-<div class="w-full text-center text-xl">Book any session with us below!</div>
-<div bind:this={calendlyRef} class="w-full h-full pb-8" />
+<div class="w-full h-full">
+	<div>
+		<h1 class="h3 font-bold text-primary-500 text-center">Book a session with us below!</h1>
+	</div>
+	<div bind:this={calendlyRef} class="w-full h-full pb-8" />
+</div>

--- a/src/routes/families/+page.server.ts
+++ b/src/routes/families/+page.server.ts
@@ -1,12 +1,16 @@
-import { getAllEventTypes, transformForEventPanel } from "$lib/server/calendarUtils"
-import type { PageServerLoad } from "./$types";
+import { getAllEventTypes, transformForEventPanel } from '$lib/server/calendarUtils';
+import type { PageServerLoad } from './$types';
 
 export const load = (async () => {
-  const allEventTypes: Array<Calendly.EventTypeData> = await getAllEventTypes();
-  const lectureEventData = transformForEventPanel(allEventTypes.filter(eventType => eventType.internalNote.toLowerCase().includes('lecture')));
-  const workshopEventData = transformForEventPanel(allEventTypes.filter(eventType => eventType.internalNote.toLowerCase().includes('workshop')));
-  return {
-    lectureEventData,
-    workshopEventData,
-  }
+	const allEventTypes: Array<Calendly.EventTypeData> = await getAllEventTypes();
+	const lectureEventData = transformForEventPanel(
+		allEventTypes.filter((eventType) => eventType.tags.includes('lecture'))
+	);
+	const workshopEventData = transformForEventPanel(
+		allEventTypes.filter((eventType) => eventType.tags.includes('workshop'))
+	);
+	return {
+		lectureEventData,
+		workshopEventData
+	};
 }) satisfies PageServerLoad;

--- a/src/routes/families/+page.server.ts
+++ b/src/routes/families/+page.server.ts
@@ -1,0 +1,12 @@
+import { getAllEventTypes, transformForEventPanel } from "$lib/server/calendarUtils"
+import type { PageServerLoad } from "./$types";
+
+export const load = (async () => {
+  const allEventTypes: Array<Calendly.EventTypeData> = await getAllEventTypes();
+  const lectureEventData = transformForEventPanel(allEventTypes.filter(eventType => eventType.internalNote.toLowerCase().includes('lecture')));
+  const workshopEventData = transformForEventPanel(allEventTypes.filter(eventType => eventType.internalNote.toLowerCase().includes('workshop')));
+  return {
+    lectureEventData,
+    workshopEventData,
+  }
+}) satisfies PageServerLoad;

--- a/src/routes/families/+page.svelte
+++ b/src/routes/families/+page.svelte
@@ -5,7 +5,7 @@
 	import type { PageData } from './$types';
 
 	export let data: PageData;
-	const { workshopEventData, lectureEventData } = data;	
+	const { workshopEventData, lectureEventData } = data;
 	const consultationLink = 'https://calendly.com/birthkuwait/consultation';
 </script>
 
@@ -13,8 +13,13 @@
 	<div class="flex flex-row flex-wrap w-full p-4 md:p-8 justify-around gap-8">
 		<Card underline class="w-[40rem] flex flex-col items-center">
 			<h2 slot="header" class="h3 font-bold text-primary-500 text-center">Ready to talk?</h2>
-			<p class="text-xl">Meet with one of our experts to craft a plan that will work best for you, whatever phase of motherhood you are in.</p>
-			<p class="text-lg mt-5 mb-5">What to expect: Some details about the consultation like length, what will be discussed, outcomes, etc.</p>
+			<p class="text-xl">
+				Meet with one of our experts to craft a plan that will work best for you, whatever phase of motherhood you are
+				in.
+			</p>
+			<p class="text-lg mt-5 mb-5">
+				What to expect: Some details about the consultation like length, what will be discussed, outcomes, etc.
+			</p>
 			<CalendlyPopupButton bookingLink={consultationLink}>Book Now!</CalendlyPopupButton>
 		</Card>
 		<Card underline class="card h-fit bg-white w-[40rem] p-6">

--- a/src/routes/families/+page.svelte
+++ b/src/routes/families/+page.svelte
@@ -1,9 +1,11 @@
-<script>
+<script lang="ts">
 	import EventsPanel from '$lib/components/EventsPanel.svelte';
-	import bkLogo from '$lib/assets/bk_logo.jpeg';
 	import Card from '$lib/components/Card.svelte';
 	import CalendlyPopupButton from '$lib/components/CalendlyPopupButton.svelte';
+	import type { PageData } from './$types';
 
+	export let data: PageData;
+	const { workshopEventData, lectureEventData } = data;	
 	const consultationLink = 'https://calendly.com/birthkuwait/consultation';
 </script>
 
@@ -34,64 +36,14 @@
 			<EventsPanel
 				title="Free Lectures"
 				description="Join us and our amazing speakers for these absolutely free lectures on fascinating topics!"
-				events={[
-					{
-						id: '123',
-						date: '07/12/2023',
-						title: 'Who is a Doula?',
-						description: 'This is a description',
-						imageSrc: bkLogo,
-						bookingLink: 'https://calendly.com/birthkuwait/free-lecture-who-is-a-doula-7-dec'
-					},
-					{
-						id: '234',
-						date: '02/12/2021',
-						title: 'My Life Guide',
-						description: 'This is a description',
-						imageSrc: bkLogo,
-						bookingLink: 'https://calendly.com/birthkuwait/free-lecture-who-is-a-doula-7-dec'
-					}
-				]}
+				events={lectureEventData}
 			/>
 		</div>
 		<div class="w-[25rem]">
 			<EventsPanel
 				title="Group Workshops"
 				description="We offer group workshops, too! Reserve your seat today. "
-				events={[
-					{
-						id: '123',
-						date: 'Thursdays',
-						title: 'Prenatal Exercise',
-						description: 'Short description',
-						imageSrc: bkLogo,
-						bookingLink: 'https://calendly.com/birthkuwait/prenatal-exercise-workshop'
-					},
-					{
-						id: '123',
-						date: 'Thursdays',
-						title: 'Childbirth Prep',
-						description: 'Short description',
-						imageSrc: bkLogo,
-						bookingLink: 'https://calendly.com/birthkuwait/childbirth-preparations-workshop'
-					},
-					{
-						id: '234',
-						date: 'Saturdays',
-						title: 'Breastfeeding Basics',
-						description: 'Short description',
-						imageSrc: bkLogo,
-						bookingLink: 'https://calendly.com/birthkuwait/breastfeeding-basics-workshop'
-					},
-					{
-						id: '123',
-						date: 'Sundays',
-						title: 'Newborn Care',
-						description: 'Short description',
-						imageSrc: bkLogo,
-						bookingLink: 'https://calendly.com/birthkuwait/newborn-care-basics-workshop'
-					}
-				]}
+				events={workshopEventData}
 			/>
 		</div>
 	</div>

--- a/src/routes/professionals/+page.server.ts
+++ b/src/routes/professionals/+page.server.ts
@@ -1,0 +1,10 @@
+import { getAllEventTypes, transformForEventPanel } from "$lib/server/calendarUtils";
+import type { PageServerLoad } from "./$types";
+
+export const load = (async () => {
+  const allEventTypes: Array<Calendly.EventTypeData> = await getAllEventTypes();
+  const trainingEventData = transformForEventPanel(allEventTypes.filter(eventType => eventType.internalNote.toLowerCase().includes('training')));
+  return {
+    trainingEventData,
+  };
+}) satisfies PageServerLoad;

--- a/src/routes/professionals/+page.server.ts
+++ b/src/routes/professionals/+page.server.ts
@@ -1,10 +1,12 @@
-import { getAllEventTypes, transformForEventPanel } from "$lib/server/calendarUtils";
-import type { PageServerLoad } from "./$types";
+import { getAllEventTypes, transformForEventPanel } from '$lib/server/calendarUtils';
+import type { PageServerLoad } from './$types';
 
 export const load = (async () => {
-  const allEventTypes: Array<Calendly.EventTypeData> = await getAllEventTypes();
-  const trainingEventData = transformForEventPanel(allEventTypes.filter(eventType => eventType.internalNote.toLowerCase().includes('training')));
-  return {
-    trainingEventData,
-  };
+	const allEventTypes: Array<Calendly.EventTypeData> = await getAllEventTypes();
+	const trainingEventData = transformForEventPanel(
+		allEventTypes.filter((eventType) => eventType.tags.includes('training'))
+	);
+	return {
+		trainingEventData
+	};
 }) satisfies PageServerLoad;

--- a/src/routes/professionals/+page.svelte
+++ b/src/routes/professionals/+page.svelte
@@ -1,7 +1,10 @@
-<script>
+<script lang="ts">
 	import EventsPanel from '$lib/components/EventsPanel.svelte';
-	import bkLogo from '$lib/assets/bk_logo.jpeg';
 	import Card from '$lib/components/Card.svelte';
+	import type { PageData } from './$types';
+
+	export let data: PageData;
+	const { trainingEventData } = data;
 </script>
 
 <section class="w-full bg-cover md:min-h-[30rem] bg-[url($lib/assets/design/professionals-background.png)]">
@@ -12,16 +15,7 @@
 	<div class="flex flex-row flex-wrap justify-around p-4 md:p-12 w-full">
 		<div class="md:w-[25rem]">
 			<EventsPanel
-				events={[
-					{
-						id: '123',
-						date: 'Weekdays',
-						title: 'One Hour Training',
-						description: 'This is a description',
-						imageSrc: bkLogo,
-						bookingLink: 'https://calendly.com/birthkuwait/professional-training'
-					}
-				]}
+				events={trainingEventData}
 				title="Professional Training"
 				description="We offer a wide selection of training sessions! Check out our schedule below and contact us for more details"
 			/>


### PR DESCRIPTION
This PR implements the Calendly API for pulling event data into the EventPanel components across the website. We are making use of a field in Calendly events called `internal note` to tag them as a training, lecture, or workshop since it is broken up as such on the website. In addition we use this to mark `featured` events for display on the homepage.

A couple of outstanding tasks, though this PR is functional as of now: 

- Need to have a fallback on the homepage if there are no events marked as `featured` to just show the top 3 results when getting all events
- Need to have a default label of "No upcoming events" if the array passed into the EventPanel is empty
- Need to implement the list view of upcoming scheduled events on the Upcoming Events page